### PR TITLE
Add functionality to disable autoupdate

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ kind: ManagedResource
 metadata:
   name: managedresource-sample
 spec:
+  avoidResourceUpdate: false
   data:
     - name: my_secret
       type: Secret
@@ -89,6 +90,7 @@ spec:
         name: managed-resource-sa
         namespace: {{ .Namespace.Name }}
 ```
+- `avoidResourceUpdate`: Optional field that changes the default behavior of reconciling existing resources with the desired state. If set to true only non-existing resources will be created an never updated. Default values is `false`.
 - `data`: Optional field that read `Secret` or `ConfigMap` and imports the contents to be used in the `template` under `.Data.<name>`.
 - `namespaceSelector`: Specifies the namespaces where you want to apply the template. You can use a regular expression (regex) to match multiple namespaces.
 - `template`: Contains the YAML template that you want to apply to the selected namespaces. You can use Go template syntax to customize the resource based on the namespace.

--- a/api/v1alpha1/managedresource_types.go
+++ b/api/v1alpha1/managedresource_types.go
@@ -67,8 +67,10 @@ type ManagedResourceSpecTemplate struct {
 
 // ManagedResourceSpec defines the desired state of ManagedResource
 type ManagedResourceSpec struct {
-	NamespaceSelector ManagedResourceSpecNamespaceSelector `json:"namespaceSelector,omitempty"`
-	Template          ManagedResourceSpecTemplate          `json:"template,omitempty"`
+	// AvoidResourceUpdate defines if the created resources should be updated if they already exists. Default value is false.
+	AvoidResourceUpdate bool                                 `json:"avoidResourceUpdate,omitempty"`
+	NamespaceSelector   ManagedResourceSpecNamespaceSelector `json:"namespaceSelector,omitempty"`
+	Template            ManagedResourceSpecTemplate          `json:"template,omitempty"`
 }
 
 // ManagedResourceStatus defines the observed state of ManagedResource

--- a/config/crd/bases/automation.kubensync.com_managedresources.yaml
+++ b/config/crd/bases/automation.kubensync.com_managedresources.yaml
@@ -35,6 +35,10 @@ spec:
           spec:
             description: ManagedResourceSpec defines the desired state of ManagedResource
             properties:
+              avoidResourceUpdate:
+                description: AvoidResourceUpdate defines if the created resources
+                  should be updated if they already exists. Default value is false.
+                type: boolean
               namespaceSelector:
                 description: ManagedResourceSpecNamespaceSelector defines the selector
                   used to specify which namespaces are affected


### PR DESCRIPTION
Resolves #3 

With this change the reconcile logic so the resources can be created and synchronized or simply created when they don't exist