### PR TITLE
Skip reconciling resources being deleted

### DIFF
--- a/pkg/controllers/managedresource_controller.go
+++ b/pkg/controllers/managedresource_controller.go
@@ -65,6 +65,9 @@ func (r *ManagedResourceReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 			return ctrl.Result{}, nil
 		}
 		return ctrl.Result{}, err
+	} else if mr.DeletionTimestamp != nil {
+		// Object is being deleted
+		return ctrl.Result{}, nil
 	}
 	err = reconcileManagedResource(ctx, r.config, mr)
 	if err != nil {

--- a/pkg/controllers/namespace_controller.go
+++ b/pkg/controllers/namespace_controller.go
@@ -41,6 +41,9 @@ func (r *NamespaceController) Reconcile(ctx context.Context, req reconcile.Reque
 			return reconcile.Result{}, nil
 		}
 		return reconcile.Result{}, err
+	} else if ns.DeletionTimestamp != nil {
+		// Object is being deleted
+		return reconcile.Result{}, nil
 	}
 	err = reconcileNamespace(ctx, r.config, ns)
 	if err != nil {


### PR DESCRIPTION
Avoid triggering the reconcile loop when the resources (MR or namespace) is being deleted, aka having a DeletionTimestamp