### PR TITLE
Add namespaces permissions with kubebuilder

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -5,6 +5,14 @@ metadata:
   name: manager-role
 rules:
 - apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - automation.kubensync.com
   resources:
   - managedresources

--- a/internal/controller/namespace_controller.go
+++ b/internal/controller/namespace_controller.go
@@ -29,7 +29,8 @@ type NamespaceController struct {
 
 var namespaceControllerLogger = ctrl.Log.WithName("namespace_controller")
 
-// ...
+// +kubebuilder:rbac:groups=core,resources=namespaces,verbs=get;list;watch
+
 func (r *NamespaceController) Reconcile(ctx context.Context, req reconcile.Request) (reconcile.Result, error) {
 	// Handle the namespace event here
 	namespaceControllerLogger.Info("Reconciling Namespace", "name", req.Name)


### PR DESCRIPTION
When installing the operator it needs basic list and watch permissions over namespaces. By default they were not granted. 