### PR TITLE
Delete resources when ns is no longer preset or matching

### DIFF
--- a/e2e/tests/bugfixes.sh
+++ b/e2e/tests/bugfixes.sh
@@ -6,75 +6,7 @@ echo "#    Starting bug replicators               #"
 echo "#                                           #"
 echo "#############################################"
 
-
-NAMESPACE="test-kubensync"
-MAX_WAIT=30
-INTERVAL=1
-
-echo "#56 - Split MRs correctly when having multiple hyphens in the resource"
-
-# MR that creates a Certificate CM on the namespace
-kubectl create -f - <<EOF
-apiVersion: automation.kubensync.com/v1alpha1
-kind: ManagedResource
-metadata:
-  name: managedresource-sample
-spec:
-    namespaceSelector:
-        regex: "$NAMESPACE"
-    template:
-        literal: |
-            ---
-            apiVersion: v1
-            kind: ConfigMap
-            metadata:
-                name: test-hyphen-certificate
-                namespace: {{ .Namespace.Name }}
-            data:
-                certificate: |-
-                    -----BEGIN CERTIFICATE-----
-                    MIIDXzCCAkcCFGm2s7nWYvZPT3EeT44nNNdC86XIMA0GCSqGSIb3DQEBCwUAMGwx
-                    CzAJBgNVBAYTAkVTMRIwEAYDVQQIDAlpbWFnaW5hcnkxITAfBgNVBAoMGEludGVy
-                    bmV0IFdpZGdpdHMgUHR5IEx0ZDESMBAGA1UECwwJS3ViZU5TeW5jMRIwEAYDVQQD
-                    DAlLdWJlTlN5bmMwHhcNMjUwNDIyMDg0OTA4WhcNMjYwNDIyMDg0OTA4WjBsMQsw
-                    CQYDVQQGEwJFUzESMBAGA1UECAwJaW1hZ2luYXJ5MSEwHwYDVQQKDBhJbnRlcm5l
-                    dCBXaWRnaXRzIFB0eSBMdGQxEjAQBgNVBAsMCUt1YmVOU3luYzESMBAGA1UEAwwJ
-                    S3ViZU5TeW5jMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAsWQF9rf7
-                    FwlzchLzK73YOrVMx/aYN8BuMJd8nnNJY9BuMMzwAdn18Ohs88usJ4PoQWbyygsx
-                    M8PPcPZdqlraErFm6cLoYCLHSFzM9wmCFagY4LpwX9IAbFOmeQngG6BedfPjs4N4
-                    uDzPu1DsJ3AJMzSMfQD8Qcp8PAtIthyar2nHF1v8Qa4/HHn9zWIBXnmwF6CGKSoz
-                    Bo+tiypjoqg/RmD38IqyhHWFHmNBQeNfjWltxEFdK2sPI6GBSRtbTB0DGIRt4NTX
-                    1yUYr9WB7uWzXeo4ku3T/fOBcxlPQRDIfAAJksCO33u02rKM1o40kp14/1a+8dcW
-                    Z+3xfgk1/12hHwIDAQABMA0GCSqGSIb3DQEBCwUAA4IBAQBeNczIdruQjst4TzOR
-                    ixZapGrmpLHlxJPsbwfyVb4Zk46UbecN9wkQaXhzJ93Dpq34XsGhlAPRv1+owzAM
-                    2ohQkApKw3bTEQP24Eh+nPPMnC/xyPdAgjyrV3RBrXqFbM4s/JaFjrRphKLL+zJQ
-                    SIeCan9YqeVHgwCp5dM52P6BZxWrdX6WSF7QJJbTs+fXkS4zdEIKzhh0rrxnFRtR
-                    LunMnH2cTmqymqrY6gGSHv+rw1Q3o9ixhkf/9GuhA2Vm1rbFAP9dFKFEPJY5bzlP
-                    RYpA6rC+FWDDJXELZp+5vPG04ik2SV6HSk3F/98BRdO9+cLnckfc3Siqf0P/DRlA
-                    rs4l
-                    -----END CERTIFICATE-----
-EOF
-
-valid=0
-for (( i=0; i<$MAX_WAIT; i+=INTERVAL )); do
-    if kubectl get configmap "test-hyphen-certificate" -n "$NAMESPACE" > /dev/null 2>&1; then
-        echo "ConfigMap test-hyphen-certificate created"
-        # Check if the ConfigMap has the correct data
-        if kubectl get configmap test-hyphen-certificate -n "$NAMESPACE" -o jsonpath='{.data.certificate}' | grep -- "-----BEGIN CERTIFICATE-----"; then
-            echo "ConfigMap test-hyphen-certificate has the correct data"
-            valid=1
-            break
-        else
-            echo "ConfigMap test-hyphen-certificate does not have the correct data"
-            exit 1
-        fi
-    fi
-    echo "Waiting for ConfigMap test-hyphen-certificate to be created..."
-    sleep $INTERVAL
-done
-if [ $valid -eq 0 ]; then
-    echo "ConfigMap test-hyphen-certificate was not created"
-    exit 1
-fi
-
-kubectl delete managedresource managedresource-sample
+SCRIPT_DIR="$(dirname "$0")"
+/bin/bash "$SCRIPT_DIR/bugfixes/2.sh"
+/bin/bash "$SCRIPT_DIR/bugfixes/56.sh"
+/bin/bash "$SCRIPT_DIR/bugfixes/59.sh"

--- a/e2e/tests/bugfixes/2.sh
+++ b/e2e/tests/bugfixes/2.sh
@@ -1,0 +1,107 @@
+set -e
+
+NAMESPACE="test-kubensync-bugs"
+MAX_WAIT=30
+INTERVAL=1
+
+kubectl create namespace "$NAMESPACE"
+
+echo "#2 - Resources outside namespace are not deleted"
+
+## OUTSIDE NAMESPACE 
+# Create a SA in the kube-system namespace for the $NAMESPACE namespace
+kubectl create -f - <<EOF
+apiVersion: automation.kubensync.com/v1alpha1
+kind: ManagedResource
+metadata:
+  name: managedresource-sample
+spec:
+    namespaceSelector:
+        regex: "$NAMESPACE"
+    template:
+        literal: |
+            ---
+            apiVersion: v1
+            kind: ServiceAccount
+            metadata:
+                name: "$NAMESPACE-sa"
+                namespace: kube-system
+EOF
+
+# When deleting the original namespace, the SA should be deleted as the trigger namespace is deleted
+kubectl delete namespace "$NAMESPACE"
+valid=0
+
+# Path the managedresource adding a label to trigger the reconciliation
+kubectl patch managedresource managedresource-sample --type=merge -p '{"metadata":{"labels":{"kubensync.com/trigger":"true"}}}'
+for (( i=0; i<$MAX_WAIT; i+=INTERVAL )); do
+    if kubectl get serviceaccount "$NAMESPACE-sa" -n kube-system > /dev/null 2>&1; then
+        echo "ServiceAccount $NAMESPACE-sa was not deleted yet"
+    else
+        echo "ServiceAccount $NAMESPACE-sa was deleted"
+        valid=1
+        break
+    fi
+    echo "Waiting for ServiceAccount $NAMESPACE-sa to be deleted..."
+    sleep $INTERVAL
+done
+
+if [ $valid -eq 0 ]; then
+    echo "ServiceAccount $NAMESPACE-sa was not deleted"
+    exit 1
+fi
+
+kubectl delete managedresource managedresource-sample
+
+## CLUSTER WIDE OBJECT
+kubectl create namespace "$NAMESPACE"
+kubectl create -f - <<EOF
+apiVersion: automation.kubensync.com/v1alpha1
+kind: ManagedResource
+metadata:
+  name: managedresource-sample
+spec:
+    namespaceSelector:
+        regex: "$NAMESPACE"
+    template:
+        literal: |
+            ---
+            apiVersion: rbac.authorization.k8s.io/v1
+            kind: ClusterRoleBinding
+            metadata:
+                name: $NAMESPACE
+            roleRef:
+                apiGroup: rbac.authorization.k8s.io
+                kind: ClusterRole
+                name: system:basic-user
+            subjects:
+              - apiGroup: rbac.authorization.k8s.io
+                kind: Group
+                name: system:authenticated
+
+EOF
+
+# When deleting the original namespace, the SA should be deleted as the trigger namespace is deleted
+kubectl delete namespace "$NAMESPACE"
+valid=0
+
+# Path the managedresource adding a label to trigger the reconciliation
+kubectl patch managedresource managedresource-sample --type=merge -p '{"metadata":{"labels":{"kubensync.com/trigger":"true"}}}'
+for (( i=0; i<$MAX_WAIT; i+=INTERVAL )); do
+    if kubectl get clusterrolebinding "$NAMESPACE" > /dev/null 2>&1; then
+        echo "ClusterRoleBinding $NAMESPACE was not deleted yet"
+    else
+        echo "ClusterRoleBinding $NAMESPACE was deleted"
+        valid=1
+        break
+    fi
+    echo "Waiting for ClusterRoleBinding $NAMESPACE to be deleted..."
+    sleep $INTERVAL
+done
+
+if [ $valid -eq 0 ]; then
+    echo "ClusterRoleBinding $NAMESPACE was not deleted"
+    exit 1
+fi
+
+kubectl delete managedresource managedresource-sample

--- a/e2e/tests/bugfixes/56.sh
+++ b/e2e/tests/bugfixes/56.sh
@@ -1,0 +1,76 @@
+set -e
+
+NAMESPACE="test-kubensync-bugs"
+MAX_WAIT=30
+INTERVAL=1
+
+kubectl create namespace "$NAMESPACE"
+
+echo "#56 - Split MRs correctly when having multiple hyphens in the resource"
+
+# MR that creates a Certificate CM on the namespace
+kubectl create -f - <<EOF
+apiVersion: automation.kubensync.com/v1alpha1
+kind: ManagedResource
+metadata:
+  name: managedresource-sample
+spec:
+    namespaceSelector:
+        regex: "$NAMESPACE"
+    template:
+        literal: |
+            ---
+            apiVersion: v1
+            kind: ConfigMap
+            metadata:
+                name: test-hyphen-certificate
+                namespace: {{ .Namespace.Name }}
+            data:
+                certificate: |-
+                    -----BEGIN CERTIFICATE-----
+                    MIIDXzCCAkcCFGm2s7nWYvZPT3EeT44nNNdC86XIMA0GCSqGSIb3DQEBCwUAMGwx
+                    CzAJBgNVBAYTAkVTMRIwEAYDVQQIDAlpbWFnaW5hcnkxITAfBgNVBAoMGEludGVy
+                    bmV0IFdpZGdpdHMgUHR5IEx0ZDESMBAGA1UECwwJS3ViZU5TeW5jMRIwEAYDVQQD
+                    DAlLdWJlTlN5bmMwHhcNMjUwNDIyMDg0OTA4WhcNMjYwNDIyMDg0OTA4WjBsMQsw
+                    CQYDVQQGEwJFUzESMBAGA1UECAwJaW1hZ2luYXJ5MSEwHwYDVQQKDBhJbnRlcm5l
+                    dCBXaWRnaXRzIFB0eSBMdGQxEjAQBgNVBAsMCUt1YmVOU3luYzESMBAGA1UEAwwJ
+                    S3ViZU5TeW5jMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAsWQF9rf7
+                    FwlzchLzK73YOrVMx/aYN8BuMJd8nnNJY9BuMMzwAdn18Ohs88usJ4PoQWbyygsx
+                    M8PPcPZdqlraErFm6cLoYCLHSFzM9wmCFagY4LpwX9IAbFOmeQngG6BedfPjs4N4
+                    uDzPu1DsJ3AJMzSMfQD8Qcp8PAtIthyar2nHF1v8Qa4/HHn9zWIBXnmwF6CGKSoz
+                    Bo+tiypjoqg/RmD38IqyhHWFHmNBQeNfjWltxEFdK2sPI6GBSRtbTB0DGIRt4NTX
+                    1yUYr9WB7uWzXeo4ku3T/fOBcxlPQRDIfAAJksCO33u02rKM1o40kp14/1a+8dcW
+                    Z+3xfgk1/12hHwIDAQABMA0GCSqGSIb3DQEBCwUAA4IBAQBeNczIdruQjst4TzOR
+                    ixZapGrmpLHlxJPsbwfyVb4Zk46UbecN9wkQaXhzJ93Dpq34XsGhlAPRv1+owzAM
+                    2ohQkApKw3bTEQP24Eh+nPPMnC/xyPdAgjyrV3RBrXqFbM4s/JaFjrRphKLL+zJQ
+                    SIeCan9YqeVHgwCp5dM52P6BZxWrdX6WSF7QJJbTs+fXkS4zdEIKzhh0rrxnFRtR
+                    LunMnH2cTmqymqrY6gGSHv+rw1Q3o9ixhkf/9GuhA2Vm1rbFAP9dFKFEPJY5bzlP
+                    RYpA6rC+FWDDJXELZp+5vPG04ik2SV6HSk3F/98BRdO9+cLnckfc3Siqf0P/DRlA
+                    rs4l
+                    -----END CERTIFICATE-----
+EOF
+
+valid=0
+for (( i=0; i<$MAX_WAIT; i+=INTERVAL )); do
+    if kubectl get configmap "test-hyphen-certificate" -n "$NAMESPACE" > /dev/null 2>&1; then
+        echo "ConfigMap test-hyphen-certificate created"
+        # Check if the ConfigMap has the correct data
+        if kubectl get configmap test-hyphen-certificate -n "$NAMESPACE" -o jsonpath='{.data.certificate}' | grep -- "-----BEGIN CERTIFICATE-----"; then
+            echo "ConfigMap test-hyphen-certificate has the correct data"
+            valid=1
+            break
+        else
+            echo "ConfigMap test-hyphen-certificate does not have the correct data"
+            exit 1
+        fi
+    fi
+    echo "Waiting for ConfigMap test-hyphen-certificate to be created..."
+    sleep $INTERVAL
+done
+if [ $valid -eq 0 ]; then
+    echo "ConfigMap test-hyphen-certificate was not created"
+    exit 1
+fi
+
+kubectl delete managedresource managedresource-sample
+kubectl delete namespace "$NAMESPACE"

--- a/e2e/tests/bugfixes/59.sh
+++ b/e2e/tests/bugfixes/59.sh
@@ -1,0 +1,60 @@
+set -e
+
+NAMESPACE="test-kubensync-bugs"
+MAX_WAIT=30
+INTERVAL=1
+
+echo "#59 - Resources not being deleted when namespace selected by label"
+
+# Create a namespace for the test
+kubectl create namespace $NAMESPACE
+
+# Label the namespace to match the label selector
+kubectl label namespace $NAMESPACE test-label=test-value
+
+# Create a ManagedResource that selects the namespace based on the label
+kubectl create -f - <<EOF
+apiVersion: automation.kubensync.com/v1alpha1
+kind: ManagedResource
+metadata:
+  name: managedresource-sample
+spec:
+  namespaceSelector:
+    labelSelector:
+      matchLabels:
+        test-label: test-value
+  template:
+    literal: |
+      ---
+      apiVersion: v1
+      kind: ServiceAccount
+      metadata:
+        name: test
+        namespace: {{ .Namespace.Name }}
+EOF
+
+# When deleting changing the label of the namespace, the ServiceAccount should be deleted as the namespace no longer triggers the MR
+kubectl label namespace $NAMESPACE test-label=test-value-2 --overwrite
+valid=0
+
+# Path the managedresource adding a label to trigger the reconciliation
+kubectl patch managedresource managedresource-sample --type=merge -p '{"metadata":{"labels":{"kubensync.com/trigger":"true"}}}'
+for (( i=0; i<$MAX_WAIT; i+=INTERVAL )); do
+    if kubectl get serviceaccount test -n $NAMESPACE > /dev/null 2>&1; then
+        echo "ServiceAccount test was not deleted yet"
+    else
+        echo "ServiceAccount test was deleted"
+        valid=1
+        break
+    fi
+    echo "Waiting for ServiceAccount test to be deleted..."
+    sleep $INTERVAL
+done
+
+if [ $valid -eq 0 ]; then
+    echo "ServiceAccount test was not deleted"
+    exit 1
+fi
+
+kubectl delete managedresource managedresource-sample
+kubectl delete namespace $NAMESPACE

--- a/internal/controller/managedresource_controller.go
+++ b/internal/controller/managedresource_controller.go
@@ -119,6 +119,16 @@ func reconcileManagedResource(ctx context.Context, config *rest.Config, managedr
 		}
 	}
 
+	// Process existing resources in status field
+	loadedManagedResource, err := kube.GetManagedResource(ctx, managedresource.GetName())
+	if err != nil {
+		return err
+	}
+	err = rdr.ReconcileMRCreatedResources(ctx, loadedManagedResource)
+	if err != nil {
+		return err
+	}
+
 	return nil
 
 }

--- a/internal/reconciler/created_resources.go
+++ b/internal/reconciler/created_resources.go
@@ -1,0 +1,87 @@
+package reconciler
+
+import (
+	"context"
+
+	automationv1alpha1 "github.com/eryalito/kubensync-operator/api/v1alpha1"
+	"github.com/eryalito/kubensync-operator/internal/kube"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	ctrl "sigs.k8s.io/controller-runtime"
+)
+
+var (
+	createdResourcesLogger      = ctrl.Log.WithName("created_resources")
+	createdResourcesLoggerDebug = ctrl.Log.WithName("created_resources").V((1))
+)
+
+func (r *Reconciler) ReconcileMRCreatedResources(ctx context.Context, managedResource *automationv1alpha1.ManagedResource) error {
+	for _, createdResource := range managedResource.Status.CreatedResources {
+		// Check if the resource still exists
+		obj := &unstructured.Unstructured{}
+		obj.SetAPIVersion(createdResource.ApiVersion)
+		obj.SetKind(createdResource.Kind)
+		obj.SetName(createdResource.Name)
+		obj.SetNamespace(createdResource.Namespace)
+		ri, err := kube.GetResourceInterfaceForUnstructured(obj, r.RestConfig)
+		if err != nil {
+			return err
+		}
+
+		_, err = ri.Get(ctx, createdResource.Name, metav1.GetOptions{})
+		if err != nil {
+			if errors.IsNotFound(err) {
+				// Resource not found, remove it from status
+				createdResourcesLoggerDebug.Info("Resource not found, removing it from status", "resource", createdResource)
+				managedResource.Status.CreatedResources = removeResource(managedResource.Status.CreatedResources, createdResource)
+			} else {
+				return err
+			}
+		} else {
+			// Logic starts here
+
+			triggerNamespaceObj, err := r.Clientset.CoreV1().Namespaces().Get(ctx, createdResource.TriggerNamespace, metav1.GetOptions{})
+			if err != nil && !errors.IsNotFound(err) {
+				return err
+			}
+			// if trigger the trigger namespace does not exist, remove the resource
+			if errors.IsNotFound(err) {
+				// Trigger namespace not found, remove the resource
+				createdResourcesLogger.Info("Trigger namespace not found, removing resource", "triggerNamespace", createdResource.TriggerNamespace, "resource", createdResource)
+				err = ri.Delete(ctx, createdResource.Name, metav1.DeleteOptions{})
+				if err != nil {
+					return err
+				}
+				managedResource.Status.CreatedResources = removeResource(managedResource.Status.CreatedResources, createdResource)
+				createdResourcesLogger.Info("Resource removed", "resource", createdResource)
+				continue
+			}
+
+			// if the resource trigger namespace no longer matches the managed resource trigger namespace, delete the resource
+
+			matches, err := namespaceMatchesManagedResource(triggerNamespaceObj, managedResource)
+			if err != nil {
+				reconcilerLogger.Error(err, "Error matching namespace with managed resource")
+				return err
+			}
+
+			if !matches {
+				// Trigger namespace does not match, remove the resource
+				createdResourcesLogger.Info("Trigger namespace does not match, removing resource", "triggerNamespace", createdResource.TriggerNamespace, "resource", createdResource)
+				err = ri.Delete(ctx, createdResource.Name, metav1.DeleteOptions{})
+				if err != nil {
+					return err
+				}
+				managedResource.Status.CreatedResources = removeResource(managedResource.Status.CreatedResources, createdResource)
+				createdResourcesLogger.Info("Resource removed", "resource", createdResource)
+			}
+
+		}
+		err = kube.UpdateStatus(managedResource, ctx)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/internal/reconciler/utils.go
+++ b/internal/reconciler/utils.go
@@ -1,0 +1,58 @@
+package reconciler
+
+import (
+	"context"
+	"regexp"
+
+	"github.com/eryalito/kubensync-operator/api/v1alpha1"
+	automationv1alpha1 "github.com/eryalito/kubensync-operator/api/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/client-go/kubernetes"
+)
+
+func namespaceMatchesManagedResource(namespace *corev1.Namespace, managedResource *automationv1alpha1.ManagedResource) (bool, error) {
+	regex, err := regexp.Compile(managedResource.Spec.NamespaceSelector.Regex)
+	if err != nil {
+		return false, err
+	}
+	if !regex.MatchString(namespace.Name) {
+		return false, nil
+	}
+	labelSelector, err := metav1.LabelSelectorAsSelector(&managedResource.Spec.NamespaceSelector.LabelSelector)
+	if err != nil {
+		return false, err
+	}
+	namespaceLabels := labels.Set(namespace.GetLabels())
+	if !labelSelector.Matches(namespaceLabels) {
+		return false, nil
+	}
+	return true, nil
+}
+
+func isNamespacePresent(name string, clientset *kubernetes.Clientset) (bool, error) {
+	if name == "" {
+		return false, nil
+	}
+	_, err := clientset.CoreV1().Namespaces().Get(context.TODO(), name, metav1.GetOptions{})
+	if err != nil {
+		if errors.IsNotFound(err) {
+			return false, nil
+		}
+		return false, err
+	}
+	return true, nil
+}
+
+// removeResource removes a CreatedResource from the slice if it exists.
+func removeResource(resources []v1alpha1.CreatedResource, target v1alpha1.CreatedResource) []v1alpha1.CreatedResource {
+	for i, resource := range resources {
+		if resource == target {
+			// Remove the element by slicing around it
+			return append(resources[:i], resources[i+1:]...)
+		}
+	}
+	return resources // Return unchanged if not found
+}

--- a/internal/reconciler/utils.go
+++ b/internal/reconciler/utils.go
@@ -1,16 +1,12 @@
 package reconciler
 
 import (
-	"context"
 	"regexp"
 
-	"github.com/eryalito/kubensync-operator/api/v1alpha1"
 	automationv1alpha1 "github.com/eryalito/kubensync-operator/api/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
-	"k8s.io/client-go/kubernetes"
 )
 
 func namespaceMatchesManagedResource(namespace *corev1.Namespace, managedResource *automationv1alpha1.ManagedResource) (bool, error) {
@@ -32,22 +28,8 @@ func namespaceMatchesManagedResource(namespace *corev1.Namespace, managedResourc
 	return true, nil
 }
 
-func isNamespacePresent(name string, clientset *kubernetes.Clientset) (bool, error) {
-	if name == "" {
-		return false, nil
-	}
-	_, err := clientset.CoreV1().Namespaces().Get(context.TODO(), name, metav1.GetOptions{})
-	if err != nil {
-		if errors.IsNotFound(err) {
-			return false, nil
-		}
-		return false, err
-	}
-	return true, nil
-}
-
 // removeResource removes a CreatedResource from the slice if it exists.
-func removeResource(resources []v1alpha1.CreatedResource, target v1alpha1.CreatedResource) []v1alpha1.CreatedResource {
+func removeResource(resources []automationv1alpha1.CreatedResource, target automationv1alpha1.CreatedResource) []automationv1alpha1.CreatedResource {
 	for i, resource := range resources {
 		if resource == target {
 			// Remove the element by slicing around it


### PR DESCRIPTION
A check added to the MR loop so the already created resources (added to the status) are check to ensure the trigger namespace that created them is still existing and matching, if not the resource is deleted.

Fixes #2 , #59 
