### PR TITLE
Fix examples functions after sprig deletion

### DIFF
--- a/docs/examples/pull-secret.md
+++ b/docs/examples/pull-secret.md
@@ -32,5 +32,5 @@ spec:
                 namespace: {{ .Namespace.Name }}
             type: kubernetes.io/dockerconfigjson
             data:
-                .dockerconfigjson: '{{ index .Data.pull_secret ".dockerconfigjson" | b64enc }}'
+                .dockerconfigjson: '{{ index .Data.pull_secret ".dockerconfigjson" | base64Encode }}'
 ```

--- a/docs/reference/template-data.md
+++ b/docs/reference/template-data.md
@@ -70,8 +70,8 @@ spec:
                 namespace: {{ .Namespace.Name }}
             type: Opaque
             data:
-                key1: {{ index .Data.my_secret "key1" | b64enc }}
-                key2: {{ index .Data.my_secret "key2" | b64enc }}
+                key1: {{ index .Data.my_secret "key1" | base64Encode }}
+                key2: {{ index .Data.my_secret "key2" | base64Encode }}
 ```
 
 ### ConfigMap

--- a/docs/reference/template.md
+++ b/docs/reference/template.md
@@ -40,7 +40,7 @@ spec:
                 namespace: {{ .Namespace.Name }}
             type: kubernetes.io/dockerconfigjson
             data:
-                .dockerconfigjson: '{{ index .Data.pull_secret ".dockerconfigjson" | b64enc }}'
+                .dockerconfigjson: '{{ index .Data.pull_secret ".dockerconfigjson" | base64Encode }}'
             ---
             # Other resources can be added here
 ```

--- a/docs/usage/index.md
+++ b/docs/usage/index.md
@@ -34,7 +34,7 @@ spec:
                 namespace: {{ .Namespace.Name }}
             type: kubernetes.io/dockerconfigjson
             data:
-                .dockerconfigjson: '{{ index .Data.pull_secret ".dockerconfigjson" | b64enc }}'
+                .dockerconfigjson: '{{ index .Data.pull_secret ".dockerconfigjson" | base64Encode }}'
 ```
 
 1.  !!! tip 


### PR DESCRIPTION
After the sprig deletion some functions have changed, so the examples must be updated to the new syntax