### PR TITLE
Split only when line starts with ---

### DIFF
--- a/internal/reconciler/reconciler.go
+++ b/internal/reconciler/reconciler.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"reflect"
-	"regexp"
 	"strings"
 	"sync"
 	"text/template"
@@ -55,18 +54,21 @@ func (r *Reconciler) ReconcileNamespaceChange(ctx context.Context, mrDef *automa
 	if err != nil {
 		return nil, err
 	}
-	manifestList := regexp.MustCompile(`^---\s*$`).Split(manifests, -1)
+	// Use apimachinery's YAML decoder to iterate over all documents in the manifest
 	remainingPrevCreatedResources := mrDef.Status.CreatedResources
 	createdAndUpdatedResourcesList := []automationv1alpha1.CreatedResource{}
-	for _, manifest := range manifestList {
-		if len(manifest) == 0 {
+	decoder := yaml.NewYAMLOrJSONDecoder(strings.NewReader(manifests), 1024)
+	for {
+		obj := &unstructured.Unstructured{}
+		err := decoder.Decode(obj)
+		if err != nil {
+			if err.Error() == "EOF" {
+				break
+			}
+			reconcilerLogger.Error(err, "Error decoding manifests")
 			continue
 		}
-		obj := &unstructured.Unstructured{}
-
-		decoder := yaml.NewYAMLOrJSONDecoder(strings.NewReader(manifest), 1024)
-		if err := decoder.Decode(obj); err != nil {
-			reconcilerLogger.Error(err, "Error deconding manifests")
+		if obj.Object == nil || len(obj.Object) == 0 {
 			continue
 		}
 

--- a/internal/reconciler/reconciler.go
+++ b/internal/reconciler/reconciler.go
@@ -55,7 +55,7 @@ func (r *Reconciler) ReconcileNamespaceChange(ctx context.Context, mrDef *automa
 	if err != nil {
 		return nil, err
 	}
-	manifestList := regexp.MustCompile(`(?m)^\s*---\s*$`).Split(manifests, -1)
+	manifestList := regexp.MustCompile(`^---\s*$`).Split(manifests, -1)
 	remainingPrevCreatedResources := mrDef.Status.CreatedResources
 	createdAndUpdatedResourcesList := []automationv1alpha1.CreatedResource{}
 	for _, manifest := range manifestList {

--- a/internal/reconciler/reconciler.go
+++ b/internal/reconciler/reconciler.go
@@ -68,7 +68,7 @@ func (r *Reconciler) ReconcileNamespaceChange(ctx context.Context, mrDef *automa
 			reconcilerLogger.Error(err, "Error decoding manifests")
 			continue
 		}
-		if obj.Object == nil || len(obj.Object) == 0 {
+		if len(obj.Object) == 0 {
 			continue
 		}
 


### PR DESCRIPTION
When templated resources has internal templates, for example when using CAAPH you define the values of a chart and might have internal resources the operator breaks as it only split by lines containing spaces and `---`.

# Example

```yaml
[...]
kind: ManagedResource
spec:
    [...]
    template:
        [...]
        literal: |
          ---
          apiVersion: addons.cluster.x-k8s.io/v1alpha1
          kind: HelmChartProxy
          spec:
            valuesTemplate: |
              ---
              [...]
              ---
              [...]
```

As this contains a `<spaces>---<spaces>` lines at the end the operator splits this like that:

first
```yaml
apiVersion: addons.cluster.x-k8s.io/v1alpha1
kind: HelmChartProxy
spec:
  valuesTemplate: |
```

second:
```yaml
[...]
```

third:
```yaml
[...]
```

# Fix
Just split by lines starting by `---` with arbitrary spaces after