### PR TITLE
build: record operator module version in the container image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,8 @@
 # More info: https://docs.docker.com/engine/reference/builder/#dockerignore-file
-# Ignore build and test binaries.
+# Only exclude files git does not track. Excluding a tracked file would leave the
+# build tree incomplete and mark the recorded module version dirty.
 bin/
+site/
+*.out
+*.test
+Dockerfile.cross

--- a/.github/workflows/build-and-publish.yaml
+++ b/.github/workflows/build-and-publish.yaml
@@ -17,6 +17,7 @@ jobs:
         uses: actions/checkout@v7
         with:
           ref: ${{ github.event.release.tag_name }}
+          fetch-depth: 0
 
       - name: Derive version from tag
         id: version

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,21 +7,21 @@ WORKDIR /workspace
 # Copy the Go Modules manifests
 COPY go.mod go.mod
 COPY go.sum go.sum
-# cache deps before building and copying source so that we don't need to re-download as much
-# and so that source changes don't invalidate our downloaded layer
+# cache deps before copying source so this layer is reused while go.mod/go.sum are unchanged
 RUN go mod download
 
-# Copy the go source
-COPY cmd/main.go cmd/main.go
-COPY api/ api/
-COPY internal/ internal/
+# Copy the whole tree, including .git, so the build records the module version from
+# the VCS tag. A partial copy leaves tracked files missing and marks the build dirty.
+COPY . .
+RUN git config --global --add safe.directory /workspace
 
 # Build
 # the GOARCH has not a default value to allow the binary be built according to the host where the command
 # was called. For example, if we call make docker-build in a local env which has the Apple Silicon M1 SO
 # the docker BUILDPLATFORM arg will be linux/arm64 when for Apple x86 it will be linux/amd64. Therefore,
 # by leaving it empty we can ensure that the container and binary shipped on it will have the same platform.
-RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o manager cmd/main.go
+# Building the package (./cmd) rather than the file lets Go record the main module path and version.
+RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o manager ./cmd
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details


### PR DESCRIPTION
Closes #178.

Makes the published image record the operator's own Go module and version, so scanners and SBOM tools can identify it (not just its dependencies).

- Build the package (`./cmd`) instead of the file, so Go records the module path.
- Copy the whole tree including `.git` and mark it a safe directory, so the build derives the module version from the VCS tag.
- `.dockerignore` excludes only untracked or ignored files, so the tracked tree stays complete and the version is not marked dirty.
- `build-and-publish.yaml` checks out with `fetch-depth: 0` so the tag is available for the version stamp.
