### PR TITLE
docs: document installing from the classic Helm repository

### DIFF
--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -26,12 +26,20 @@ Grant Permissions:
 
 ### Using Helm
 
-Install the operator using the Helm chart:
+Add the kubensync repository and install the chart:
 
-    helm install kubensync oci://ghcr.io/eryalito/kubensync-charts/kubensync --version 0.10.0 -n kubensync-system --create-namespace --wait
+    helm repo add kubensync https://kubensync.com/charts
+    helm repo update
+    helm install kubensync kubensync/kubensync -n kubensync-system --create-namespace --wait
 
 !!! info "Helm Chart"
     To get more information about the Helm chart, check the [Helm Chart documentation](https://github.com/eryalito/kubensync-operator/tree/master/dist/chart)
+
+#### OCI registry
+
+The chart is also published to an OCI registry, which is useful for air-gapped environments or registry mirroring:
+
+    helm install kubensync oci://ghcr.io/eryalito/kubensync-charts/kubensync --version <version> -n kubensync-system --create-namespace --wait
 
 ## Uninstallation
 


### PR DESCRIPTION
Updates the Getting Started guide to make the classic Helm repository the primary install path:

    helm repo add kubensync https://kubensync.com/charts
    helm install kubensync kubensync/kubensync -n kubensync-system --create-namespace --wait

The OCI registry install moves to its own subsection, kept for air-gapped environments and registry mirroring. This also removes the hardcoded (and outdated) chart version from the install command.

The repository is already live and serves every chart version from 0.9.3 onward.